### PR TITLE
POSSE-935: quiet logs due to Riskified bug

### DIFF
--- a/src/RiskifiedAsync/DecisionNotification/Model/Notification.php
+++ b/src/RiskifiedAsync/DecisionNotification/Model/Notification.php
@@ -99,7 +99,10 @@ class Notification {
         $this->status = $order->{'status'};
         $this->oldStatus = $order->{'old_status'};
         $this->description = $order->{'description'};
-        $this->category = $order->{'category'};
-        $this->decisionCode = $order->{'decision_code'};
+
+        if (array_key_exists('category', $order))
+            $this->category = $order->{'category'};
+        if (array_key_exists('decision_code', $order))
+            $this->decisionCode = $order->{'decision_code'};
     }
 }


### PR DESCRIPTION
Due to a updating to the latest version (1.8.5) of Riskified's php sdk, we now have a pretty constant stream of these in our logs:

```grails.CRITICAL: Notice: Undefined property: stdClass::$category  in /www/grails/production/shared/magento/app/code/local/Grails/vendor/riskified/php_sdk/src/Riskified/DecisionNotification/Model/Notification.php on line 102```

This should fix that for our existing async integration.

Here are the changes specifically from [an internal Riskified PR](https://github.com/Riskified/php_sdk/pull/37) :

https://github.com/Riskified/php_sdk/blob/b366bace63c2d9e1844d5f812ab279230e5c4a57/src/Riskified/DecisionNotification/Model/Notification.php#L103-L107